### PR TITLE
Avoid Math.sqrt() in ShakeDetector

### DIFF
--- a/library/src/main/java/com/squareup/seismic/ShakeDetector.java
+++ b/library/src/main/java/com/squareup/seismic/ShakeDetector.java
@@ -91,7 +91,9 @@ public class ShakeDetector implements SensorEventListener {
     float ay = event.values[1];
     float az = event.values[2];
 
-    // Avoid Math.sqrt().
+    // Instead of comparing magnitude to ACCELERATION_THRESHOLD,
+    // compare their squares. This is equivalent and doesn't need the 
+    // actual magnitude, which would be computed using (expesive) Math.sqrt().
     final double magnitudeSquared = ax * ax + ay * ay + az * az;
     return magnitudeSquared > ACCELERATION_THRESHOLD * ACCELERATION_THRESHOLD;
   }


### PR DESCRIPTION
Given both `magnitude` and `ACCELERATION_THRESHOLD` are positive, the following are equivalent:

```
magnitude > ACCELERATION_THRESHOLD

magnitude * magnitude > ACCELERATION_THRESHOLD * ACCELERATION_THRESHOLD
```

The second one is more efficient.
