### PR TITLE
Clears sample queue on stop()

### DIFF
--- a/library/src/main/java/com/squareup/seismic/ShakeDetector.java
+++ b/library/src/main/java/com/squareup/seismic/ShakeDetector.java
@@ -75,6 +75,7 @@ public class ShakeDetector implements SensorEventListener {
    */
   public void stop() {
     if (accelerometer != null) {
+      queue.clear();
       sensorManager.unregisterListener(this, accelerometer);
       sensorManager = null;
       accelerometer = null;


### PR DESCRIPTION
Due to the workaround of keeping at least MIN_QUEUE_SIZE in the sample
queue stale SensorEvents will be kept even after MAX_WINDOW_SIZE.  It is
therefore possible that a isShaking() event will be emitted to the listener
immediately after restarting (start() -> stop() -> wait x seconds -> start())  because they don't
 get purged correctly. This  is a very common use case when one
 uses it to start in onResume() and stops it in onPause().

Here is a minimal example on how to reproduce it:

https://gist.github.com/patrickfav/e6d6eb63fc0bea30f87b94d3e7b29c9c

When the user shakes in the MainActivity, the HearShakeActivity gets startet. After waiting arbitrary amount of seconds pressing back in the HearShakeActivity immediatly restarts HearShakeActivity. (I can reproduce it on my Nexus 6p; maybe slower devices cannot reproduce this bug)

By clearing the queue on stop(), start() will start with a clear sample queue without stale events from seconds/minutes ago. This should not break any contract, since it would be very unintuitive to expect the sample queue stretching over the stopped phase.

Regarding testing: unfortunately I did not find a way to manually create SensorEvents to test the detector's stop behavior. Making this testable would require some refactoring, which would make the whole project really verbose.

Disclaimer: I signed Individual Contributor License Agreement