### PR TITLE
Making sensor delay configurable

### DIFF
--- a/library/src/main/java/com/squareup/seismic/ShakeDetector.java
+++ b/library/src/main/java/com/squareup/seismic/ShakeDetector.java
@@ -71,7 +71,7 @@ public class ShakeDetector implements SensorEventListener {
     }
 
     accelerometer = sensorManager.getDefaultSensor(
-            Sensor.TYPE_ACCELEROMETER);
+        Sensor.TYPE_ACCELEROMETER);
 
     // If this phone has an accelerometer, listen to it.
     if (accelerometer != null) {

--- a/library/src/main/java/com/squareup/seismic/ShakeDetector.java
+++ b/library/src/main/java/com/squareup/seismic/ShakeDetector.java
@@ -56,8 +56,11 @@ public class ShakeDetector implements SensorEventListener {
   }
 
   /**
-   * Starts listening for shakes on devices with appropriate hardware. Allowing to set the sensor delay, available values are:
-   * SENSOR_DELAY_FASTEST, SENSOR_DELAY_GAME, SENSOR_DELAY_UI, SENSOR_DELAY_NORMAL. @see <a href="https://developer.android.com/reference/android/hardware/SensorManager">SensorManager</a>
+   * Starts listening for shakes on devices with appropriate hardware.
+   * Allowing to set the sensor delay, available values are:
+   * SENSOR_DELAY_FASTEST, SENSOR_DELAY_GAME, SENSOR_DELAY_UI, SENSOR_DELAY_NORMAL.
+   * @see <a
+   * href="https://developer.android.com/reference/android/hardware/SensorManager">SensorManager</a>
    *
    * @return true if the device supports shake detection.
    */

--- a/library/src/main/java/com/squareup/seismic/ShakeDetector.java
+++ b/library/src/main/java/com/squareup/seismic/ShakeDetector.java
@@ -52,19 +52,28 @@ public class ShakeDetector implements SensorEventListener {
    * @return true if the device supports shake detection.
    */
   public boolean start(SensorManager sensorManager) {
+    return start(sensorManager, SensorManager.SENSOR_DELAY_FASTEST);
+  }
+
+  /**
+   * Starts listening for shakes on devices with appropriate hardware. Allowing to set the sensor delay, available values are:
+   * SENSOR_DELAY_FASTEST, SENSOR_DELAY_GAME, SENSOR_DELAY_UI, SENSOR_DELAY_NORMAL. @see <a href="https://developer.android.com/reference/android/hardware/SensorManager">SensorManager</a>
+   *
+   * @return true if the device supports shake detection.
+   */
+  public boolean start(SensorManager sensorManager, int sensorDelay) {
     // Already started?
     if (accelerometer != null) {
       return true;
     }
 
     accelerometer = sensorManager.getDefaultSensor(
-        Sensor.TYPE_ACCELEROMETER);
+            Sensor.TYPE_ACCELEROMETER);
 
     // If this phone has an accelerometer, listen to it.
     if (accelerometer != null) {
       this.sensorManager = sensorManager;
-      sensorManager.registerListener(this, accelerometer,
-          SensorManager.SENSOR_DELAY_FASTEST);
+      sensorManager.registerListener(this, accelerometer, sensorDelay);
     }
     return accelerometer != null;
   }


### PR DESCRIPTION
As a new requirement in Android 12 and fixing https://github.com/square/seismic/issues/24.

The change is just expose a new start method that exposes an int parameter to configure the sensor delay.

Please, don't hesitate to ask me for changes if needed :)